### PR TITLE
Use HTTPS wherever possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ It's intent is to be compatible with classic work queue solutions (RabbitMQ, Bea
 Current implementations:
 
 - InMemory: synchronous implementation, task are executed directly (useful for tests or dev environments)
-- [RabbitMQ](http://www.rabbitmq.com/)
-- [Beanstalkd](http://kr.github.io/beanstalkd/)
+- [RabbitMQ](https://www.rabbitmq.com/)
+- [Beanstalkd](https://kr.github.io/beanstalkd/)
 
 Feel free to contribute and submit other implementations (Gearman, …).
 

--- a/couscous.yml
+++ b/couscous.yml
@@ -2,7 +2,7 @@ templateUrl: https://github.com/myclabs/couscous-template
 
 template:
     # Base URL of the published website
-    baseUrl: http://myclabs.github.io/Work
+    baseUrl: https://myclabs.github.io/Work
 
     github:
         user: myclabs

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -7,8 +7,8 @@ apt-get install -y python-software-properties
 add-apt-repository -y ppa:ondrej/php5
 
 # RabbitMQ
-echo "deb http://www.rabbitmq.com/debian/ testing main" > /etc/apt/sources.list.d/rabbitmq.list
-wget http://www.rabbitmq.com/rabbitmq-signing-key-public.asc
+echo "deb https://www.rabbitmq.com/debian/ testing main" > /etc/apt/sources.list.d/rabbitmq.list
+wget https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
 apt-key add rabbitmq-signing-key-public.asc
 
 apt-get update


### PR DESCRIPTION
After noticing that the website of https://github.com/myclabs/jquery.confirm/pull/51 is broken when visiting it using HTTPS and doing a PR to fix it there, here's one to fix it for this lib's website, too :) 

As a secure connection is always a good thing and there's no reason for _not_ using it, I changed the URLs to HTTPS whereever possible.
